### PR TITLE
fix: add shim methods to allow for "pixi.js-legacy" canvas fallback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ if (typeof document === 'undefined') {
                     case '2d':
                       return {
                         fillRect: () => {},
+                        drawImage: () => {},
+                        getImageData: () => {},
                       };
                   }
                 },


### PR DESCRIPTION
Pleased to report the shim package works fine in my (non-Sveltekit, custom node/webpack SSR) application, once I'd figured out the best place to insert it (was trying to get either Webpack or my server bundle to include the shim globally, but it was causing `react-dom` to start trying to call browser code, but importing it before my `pixi` imports in my app bundle works fine).

However I'm using the canvas fallback package `pixi.js-legacy` and it complained about 2 further missing methods for the `2d` context: `drawImage` and `getImageData`. Once I added those to the shim, everything worked.

Thanks!