### PR TITLE
Add fix for CanvasRenderingContext2D

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ if (typeof document === 'undefined') {
         },
     } as any;
   }
+if (typeof CanvasRenderingContext2D === 'undefined') {
+    globalThis.CanvasRenderingContext2D = { prototype: {} };
 }
 
 export {};


### PR DESCRIPTION
In PixiJS 6.2.0, there is a check as following:

`var supportLetterSpacing = 'letterSpacing' in CanvasRenderingContext2D.prototype || 'textLetterSpacing' in CanvasRenderingContext2D.prototype;`

See: pixijs/pixijs#7958